### PR TITLE
FIX - thumbsup & Down now have boolean value

### DIFF
--- a/components/dashView/CandidateTile.tsx
+++ b/components/dashView/CandidateTile.tsx
@@ -42,12 +42,12 @@ export const CandidateTile: React.FC<CandidateTileProps> = ({
   const [thumbDownCheck, thumbDownSetCheck] = useState(false);
 
   const thumbUpClick = () => {
-    thumbUpSetCheck(true);
+    thumbUpSetCheck((prevCheck) => !prevCheck);
     thumbDownSetCheck(false);
   };
 
   const thumbDownClick = () => {
-    thumbDownSetCheck(true);
+    thumbDownSetCheck((prevCheck) => !prevCheck);
     thumbUpSetCheck(false);
   };
 


### PR DESCRIPTION
<img width="1158" alt="Screen Shot 2021-11-30 at 9 59 21 PM" src="https://user-images.githubusercontent.com/87824467/144164017-8fa85a78-e09d-4ebe-87b3-ed911f60a2f2.png">

@mayuranganesathas - also now you can only select thumb up or down...not both.


Now we have the boolean to filter.